### PR TITLE
fix: update version to 0.6.0

### DIFF
--- a/cmd/dingo/main.go
+++ b/cmd/dingo/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	version = "0.4.1"
+	version = "0.6.0"
 )
 
 func main() {


### PR DESCRIPTION
The version in main.go was still set to 0.4.1, but the latest release is v0.6.0 (December 10, 2025).
Causes the --version to be mismatched with what is seen in github.