### PR TITLE
test(tokenizer): cover ENUM and GUARD keywords at both surfaces

### DIFF
--- a/pkg/tokenizer/tokenizer_test.go
+++ b/pkg/tokenizer/tokenizer_test.go
@@ -35,6 +35,8 @@ func TestTokenIsKeyword(t *testing.T) {
 		{MATCH, true},
 		{IF, true},
 		{WHERE, true},
+		{ENUM, true},
+		{GUARD, true},
 		{IDENT, false},
 		{ARROW, false},
 		{COMMENT, false},
@@ -116,7 +118,7 @@ func TestScannerPosition(t *testing.T) {
 }
 
 func TestTokenizeIdentifiers(t *testing.T) {
-	src := []byte("match if where foo bar_123")
+	src := []byte("match if where enum guard foo bar_123")
 	tok := New(src)
 
 	tokens, err := tok.Tokenize()
@@ -131,6 +133,8 @@ func TestTokenizeIdentifiers(t *testing.T) {
 		{MATCH, "match"},
 		{IF, "if"},
 		{WHERE, "where"},
+		{ENUM, "enum"},
+		{GUARD, "guard"},
 		{IDENT, "foo"},
 		{IDENT, "bar_123"},
 		{EOF, ""},


### PR DESCRIPTION
Add ENUM and GUARD to two complementary tokenizer tests:

- `TestTokenIsKeyword` checks the `IsKeyword()` predicate that classifies a `TokenKind` once it already exists.
- `TestTokenizeIdentifiers` drives the full scanner over a source buffer and asserts the resulting `TokenKind` values, so it covers the keyword-lookup map that maps identifier text -> kind.

These surfaces are independent: removing `"enum"`/`"guard"` from the keyword map in `tokenizer.go` only breaks `TestTokenizeIdentifiers`, because `IsKeyword()` works on the `TokenKind` itself. Covering both catches regressions in either direction.