### PR TITLE
fix(ast/enum_parser): allow arbitrary nesting of '*' and '[]' in variant field types

### DIFF
--- a/pkg/ast/enum_parser.go
+++ b/pkg/ast/enum_parser.go
@@ -317,17 +317,19 @@ func (p *EnumParser) parseStructFields() ([]*EnumField, error) {
 func (p *EnumParser) parseTypeExpr() (*TypeExpr, error) {
 	start := p.pos
 
-	// Handle pointer types
-	for p.peek() == '*' {
-		p.advance()
-	}
-
-	// Handle slice types
-	if p.peek() == '[' {
-		p.advance()
-		if p.peek() == ']' {
+	// Accept any number of '*' (pointer) and '[]' (slice) prefixes in any order.
+	// Supports *T, []T, []*T, *[]T, [][]T, **T, etc.
+	for {
+		if p.peek() == '*' {
 			p.advance()
+			continue
 		}
+		if p.peek() == '[' && p.pos+1 < len(p.src) && p.src[p.pos+1] == ']' {
+			p.advance() // '['
+			p.advance() // ']'
+			continue
+		}
+		break
 	}
 
 	// Parse base type name

--- a/pkg/ast/enum_parser_test.go
+++ b/pkg/ast/enum_parser_test.go
@@ -1,0 +1,200 @@
+package ast
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestEnumParser_TypePrefixes covers parseTypeExpr's handling of pointer (*),
+// slice ([]), and any nesting/order of the two. The original implementation
+// accepted only `**T` or `*[]T`-shaped prefixes (pointers first, then a single
+// slice), which silently rejected `[]*T`, `[][]T`, `[]*[]T`, etc. The
+// transpilation pipeline turned that rejection into a confusing
+// "expected declaration, found enum" error downstream.
+func TestEnumParser_TypePrefixes(t *testing.T) {
+	tests := []struct {
+		name     string
+		src      string
+		wantType string // expected Text of the parsed field type
+	}{
+		{
+			name:     "plain type",
+			src:      `enum E { V { x: int } }`,
+			wantType: "int",
+		},
+		{
+			name:     "pointer",
+			src:      `enum E { V { x: *Foo } }`,
+			wantType: "*Foo",
+		},
+		{
+			name:     "double pointer",
+			src:      `enum E { V { x: **Foo } }`,
+			wantType: "**Foo",
+		},
+		{
+			name:     "slice of value",
+			src:      `enum E { V { x: []Foo } }`,
+			wantType: "[]Foo",
+		},
+		{
+			name:     "slice of pointer",
+			src:      `enum E { V { x: []*Foo } }`,
+			wantType: "[]*Foo",
+		},
+		{
+			name:     "pointer to slice",
+			src:      `enum E { V { x: *[]Foo } }`,
+			wantType: "*[]Foo",
+		},
+		{
+			name:     "slice of slice",
+			src:      `enum E { V { x: [][]int } }`,
+			wantType: "[][]int",
+		},
+		{
+			name:     "slice of slice of pointer",
+			src:      `enum E { V { x: [][]*Foo } }`,
+			wantType: "[][]*Foo",
+		},
+		{
+			name:     "generic with slice arg",
+			src:      `enum E { V { x: Result[[]int, error] } }`,
+			wantType: "Result[[]int, error]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewEnumParser([]byte(tt.src), 0)
+			decl, _, err := p.ParseEnumDecl()
+			if err != nil {
+				t.Fatalf("ParseEnumDecl(%q) returned error: %v", tt.src, err)
+			}
+			if len(decl.Variants) != 1 {
+				t.Fatalf("expected 1 variant, got %d", len(decl.Variants))
+			}
+			v := decl.Variants[0]
+			if v.Kind != StructVariant {
+				t.Fatalf("expected struct variant, got %v", v.Kind)
+			}
+			if len(v.Fields) != 1 {
+				t.Fatalf("expected 1 field, got %d", len(v.Fields))
+			}
+			got := v.Fields[0].Type.Text
+			if got != tt.wantType {
+				t.Errorf("field type = %q, want %q", got, tt.wantType)
+			}
+		})
+	}
+}
+
+// TestEnumParser_TupleTypePrefixes covers the same prefix handling in tuple
+// variant fields. parseTupleFields shares parseTypeExpr with parseStructFields,
+// so a regression in either context surfaces here too.
+func TestEnumParser_TupleTypePrefixes(t *testing.T) {
+	tests := []struct {
+		name      string
+		src       string
+		wantTypes []string
+	}{
+		{
+			name:      "single slice-of-pointer",
+			src:       `enum E { V([]*Foo) }`,
+			wantTypes: []string{"[]*Foo"},
+		},
+		{
+			name:      "mixed prefixes",
+			src:       `enum E { V(*Foo, []*Bar, [][]int) }`,
+			wantTypes: []string{"*Foo", "[]*Bar", "[][]int"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewEnumParser([]byte(tt.src), 0)
+			decl, _, err := p.ParseEnumDecl()
+			if err != nil {
+				t.Fatalf("ParseEnumDecl(%q) returned error: %v", tt.src, err)
+			}
+			if len(decl.Variants) != 1 {
+				t.Fatalf("expected 1 variant, got %d", len(decl.Variants))
+			}
+			v := decl.Variants[0]
+			if v.Kind != TupleVariant {
+				t.Fatalf("expected tuple variant, got %v", v.Kind)
+			}
+			if len(v.Fields) != len(tt.wantTypes) {
+				t.Fatalf("expected %d fields, got %d", len(tt.wantTypes), len(v.Fields))
+			}
+			for i, want := range tt.wantTypes {
+				got := v.Fields[i].Type.Text
+				if got != want {
+					t.Errorf("field %d type = %q, want %q", i, got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestTransformSource_SliceOfPointer is an end-to-end regression test:
+// before the fix, a `[]*T` field on an enum variant caused the dingo→go
+// transformation to leave the `enum` keyword in the output, producing a
+// downstream go/parser error of the form
+//
+//	"expected declaration, found enum"
+//
+// After the fix the source is transformed cleanly and the generated Go
+// contains the variant struct with the correct slice-of-pointer field.
+func TestTransformSource_SliceOfPointer(t *testing.T) {
+	src := []byte(`package main
+
+enum D { Foo { xs: []*Name, n: int } }
+
+type Name struct { v string }
+`)
+	got, err := TransformSource(src, "test.dingo")
+	if err != nil {
+		t.Fatalf("TransformSource returned error: %v", err)
+	}
+	out := string(got)
+	if strings.Contains(out, "enum ") {
+		t.Errorf("transformed output still contains 'enum' keyword:\n%s", out)
+	}
+	// The variant struct should carry the field with its original slice-of-pointer type.
+	if !strings.Contains(out, "xs []*Name") {
+		t.Errorf("expected `xs []*Name` field in generated Go, got:\n%s", out)
+	}
+}
+
+// TestTransformSource_MultiLineVariantBody confirms that a struct variant
+// whose fields are newline-separated (no trailing commas) still parses.
+// This was suspected to be broken alongside the slice-of-pointer bug but is
+// actually fine; this test guards against future regressions in
+// parseStructFields, which relies on skipWhitespaceAndCommas treating
+// newlines as separators.
+func TestTransformSource_MultiLineVariantBody(t *testing.T) {
+	src := []byte(`package main
+
+enum D { Foo {
+    a: int
+    b: *Name
+    c: []*Name
+} }
+
+type Name struct { v string }
+`)
+	got, err := TransformSource(src, "test.dingo")
+	if err != nil {
+		t.Fatalf("TransformSource returned error: %v", err)
+	}
+	out := string(got)
+	if strings.Contains(out, "enum ") {
+		t.Errorf("transformed output still contains 'enum' keyword:\n%s", out)
+	}
+	for _, want := range []string{"a int", "b *Name", "c []*Name"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in generated Go, got:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`EnumParser.parseTypeExpr` was conservative about how it parsed type prefixes on struct- and tuple-variant fields. It accepted any number of `*` prefixes followed by **at most one** `[]`, and **only** in the order `<pointers><slice><name>`. So:

| Type        | Before | After |
|-------------|--------|-------|
| `*T`        | ✅     | ✅    |
| `**T`       | ✅     | ✅    |
| `*[]T`      | ✅     | ✅    |
| `[]T`       | ✅     | ✅    |
| `[]*T`      | ❌     | ✅    |
| `[][]T`     | ❌     | ✅    |
| `[][]*T`    | ❌     | ✅    |

When the parser hit a rejected prefix, the failure surfaced two phases later as a confusing
```
parse error: expected declaration, found enum
```
pointing at the enum's opening line — making the real cause hard to spot.

The fix replaces the two ad-hoc loops with a single loop that consumes `*` and `[]` in any order and any count, matching what the rest of the Dingo pipeline already accepts for ordinary field types.

## Test plan

- [x] `go test ./pkg/ast/...` (new `TestEnumParser_TypePrefixes` covers 9 prefix shapes for struct variants, `TestEnumParser_TupleTypePrefixes` covers 2 for tuple variants)
- [x] `go test ./...` (full suite stays green; no other parser/codegen regression)
- [x] End-to-end `TransformSource` regression for the previously failing `[]*Name` field plus a multi-line variant body

🤖 Generated with [Claude Code](https://claude.com/claude-code)