### PR TITLE
feat(feature): add Validator plugin extension and character-level pre-transform phase

### DIFF
--- a/pkg/feature/engine.go
+++ b/pkg/feature/engine.go
@@ -2,7 +2,9 @@ package feature
 
 import (
 	"fmt"
+	"go/ast"
 	"go/token"
+	"go/types"
 	"sort"
 )
 
@@ -86,6 +88,13 @@ func (e *Engine) loadPlugins() error {
 	})
 
 	return nil
+}
+
+// IsEnabled reports whether a feature is enabled in this engine. The caller
+// can use this to gate optional pipeline phases on a particular plugin's
+// config without having to walk EnabledPluginNames.
+func (e *Engine) IsEnabled(name string) bool {
+	return e.isEnabled(name)
 }
 
 // isEnabled checks if a feature is enabled
@@ -272,6 +281,46 @@ func (e *Engine) checkDisabledSyntax(src []byte) error {
 // Registry returns the shared registry for direct access
 func (e *Engine) Registry() *SharedRegistry {
 	return e.registry
+}
+
+// Validate runs every enabled plugin that implements Validator against the
+// post-typecheck Go AST + type info. Plugins access their previously stored
+// annotations via the shared registry. Errors are concatenated in plugin
+// priority order; the caller decides how to surface them.
+//
+// Plugins are walked in the same order as Transform (character-level first,
+// then token-level), each sorted by Priority. Plugins that do not implement
+// Validator are skipped.
+func (e *Engine) Validate(fset *token.FileSet, file *ast.File, info *types.Info, filename string) []ValidationError {
+	ctx := &ValidateContext{
+		FileSet:  fset,
+		GoFile:   file,
+		TypeInfo: info,
+		Registry: e.registry,
+		Filename: filename,
+	}
+
+	var errs []ValidationError
+	collect := func(p Plugin) {
+		v, ok := p.(Validator)
+		if !ok {
+			return
+		}
+		pluginErrs := v.Validate(ctx)
+		for i := range pluginErrs {
+			if pluginErrs[i].Plugin == "" {
+				pluginErrs[i].Plugin = p.Name()
+			}
+		}
+		errs = append(errs, pluginErrs...)
+	}
+	for _, p := range e.charPlugins {
+		collect(p)
+	}
+	for _, p := range e.tokenPlugins {
+		collect(p)
+	}
+	return errs
 }
 
 // EnabledPluginNames returns the names of all enabled plugins

--- a/pkg/feature/plugin.go
+++ b/pkg/feature/plugin.go
@@ -3,7 +3,10 @@
 package feature
 
 import (
+	"fmt"
+	"go/ast"
 	"go/token"
+	"go/types"
 	"sort"
 	"sync"
 )
@@ -146,6 +149,75 @@ const (
 	// EnumRegistryKey stores enum definitions for use by match plugin
 	EnumRegistryKey = "enum_definitions"
 )
+
+// Validator is an optional plugin extension. Plugins that need to inspect
+// the Go AST + type information AFTER transformation and type checking
+// implement this interface in addition to Plugin.
+//
+// The engine collects every registered, enabled plugin that implements
+// Validator and runs Validate in priority order during the post-typecheck
+// validation phase. Errors are reported at Dingo source positions (Pos is
+// already a token.Pos into the active FileSet; Line/Column are populated
+// by Validate for convenience).
+type Validator interface {
+	// Validate runs after Go AST construction and type checking.
+	// The plugin reads its own annotations from ctx.Registry (set during
+	// Transform), inspects ctx.GoFile against ctx.TypeInfo, and returns
+	// a slice of validation errors. nil / empty slice means "all good".
+	Validate(ctx *ValidateContext) []ValidationError
+}
+
+// ValidateContext provides the post-AST validation environment to a
+// Validator plugin. All fields are read-only for the plugin.
+type ValidateContext struct {
+	// FileSet is the active token.FileSet for the parsed Go AST.
+	FileSet *token.FileSet
+
+	// GoFile is the Go AST after all source transformations.
+	GoFile *ast.File
+
+	// TypeInfo is the type checker result for GoFile. May be nil if type
+	// inference was disabled or failed; validators should degrade gracefully.
+	TypeInfo *types.Info
+
+	// Registry is the shared cross-phase registry. Validators retrieve
+	// annotations previously stored by their Transform pass via a
+	// plugin-specific key (conventionally "<plugin>_annotations").
+	Registry *SharedRegistry
+
+	// Filename is the original Dingo source filename (for diagnostics).
+	Filename string
+}
+
+// ValidationError is a structured diagnostic from a Validator plugin.
+// Pos points at a position in ctx.FileSet; Line/Column are 1-based and
+// populated by the validator for convenience.
+type ValidationError struct {
+	// Plugin is the name of the plugin that produced the error. Plugins
+	// may leave this empty; the engine populates it from p.Name() before
+	// returning the error to the caller. The pipeline uses it to prefix
+	// the diagnostic with a feature-agnostic label (e.g. "<plugin> check
+	// error at ...").
+	Plugin string
+
+	// Pos points into the active FileSet.
+	Pos token.Pos
+
+	// Line is the 1-based line number in the Dingo source.
+	Line int
+
+	// Column is the 1-based column number in the Dingo source.
+	Column int
+
+	// Message describes the problem (no file path prefix; the engine adds it).
+	Message string
+}
+
+// Error implements the error interface for ValidationError so callers can
+// surface it via the standard error machinery.
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("%d:%d: %s", e.Line, e.Column, e.Message)
+}
 
 // --- Plugin Registry ---
 

--- a/pkg/transpiler/pure_pipeline.go
+++ b/pkg/transpiler/pure_pipeline.go
@@ -7,17 +7,32 @@ import (
 	"go/printer"
 	"go/scanner"
 	"go/token"
+	"go/types"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
 	dingoast "github.com/MadAppGang/dingo/pkg/ast"
+	"github.com/MadAppGang/dingo/pkg/config"
+	"github.com/MadAppGang/dingo/pkg/feature"
+	_ "github.com/MadAppGang/dingo/pkg/feature/builtin" // register built-in plugins
 	"github.com/MadAppGang/dingo/pkg/sourcemap"
 	"github.com/MadAppGang/dingo/pkg/typechecker"
 	"github.com/MadAppGang/dingo/pkg/typeloader"
 	"github.com/MadAppGang/dingo/pkg/validator"
 )
+
+// loadFeatureEnabled produces the feature.EnabledFeatures map from the active
+// dingo.toml FeatureMatrix. If the config cannot be loaded, every feature
+// defaults to enabled (the engine-level default).
+func loadFeatureEnabled() feature.EnabledFeatures {
+	cfg, err := config.Load(nil)
+	if err != nil || cfg == nil {
+		return nil
+	}
+	return cfg.FeatureMatrix.ToEnabledFeatures()
+}
 
 // profileTranspile enables timing output for each transpilation stage.
 // Set DINGO_PROFILE=1 to enable.
@@ -216,6 +231,27 @@ func PureASTTranspileWithMappingsOpts(source []byte, filename string, opts Trans
 	fullEnumRegistry := dingoast.ExtractFullEnumRegistry(source)
 	logTiming("Extract full enum registry", stageStart)
 
+	// Step 0.5: Run every enabled character-level feature plugin against the
+	// raw source. Plugins are invoked in priority order by the feature
+	// engine — the core pipeline does not know about any specific plugin by
+	// name. External plugins (e.g. dingo-mut) opt in by blank-importing
+	// themselves from the consuming binary; they register via init() and
+	// then participate in this pass like any built-in plugin.
+	stageStart = time.Now()
+	featureEnabled := loadFeatureEnabled()
+	featureEngine, featureEngineErr := feature.NewEngine(featureEnabled)
+	if featureEngineErr != nil {
+		return TranspileResult{}, fmt.Errorf("feature engine init: %w", featureEngineErr)
+	}
+	transformedByPlugins, pluginErr := featureEngine.TransformCharacterLevel(source, filename)
+	if pluginErr != nil {
+		return TranspileResult{}, fmt.Errorf("%s: %w", filename, pluginErr)
+	}
+	if transformedByPlugins != nil {
+		source = transformedByPlugins
+	}
+	logTiming("Step 0.5: Character-level feature plugins", stageStart)
+
 	// Step 1: Transform Dingo syntax to Go using token-based transformations
 	stageStart = time.Now()
 	transformedSource, err := dingoast.TransformSource(source, filename)
@@ -317,7 +353,7 @@ func PureASTTranspileWithMappingsOpts(source []byte, filename string, opts Trans
 	// Both are metadata - no machine comments in the generated code
 	lineMappings = append(lineMappings, astLineMappings...)
 
-	// Step 3: Parse the transformed Go source with standard go/parser
+	// Step 3 (parse): Parse the transformed Go source with standard go/parser
 	stageStart = time.Now()
 	fset := token.NewFileSet()
 	goFile, err := goparser.ParseFile(fset, filename, transformedSource, goparser.ParseComments)
@@ -372,6 +408,30 @@ func PureASTTranspileWithMappingsOpts(source []byte, filename string, opts Trans
 		return TranspileResult{}, fmt.Errorf("none inference: %w", err)
 	}
 	logTiming("Step 3.5: None inference", stageStart)
+
+	// Step 3.55: Run the feature engine's Validate pass.
+	//
+	// Every enabled plugin that implements feature.Validator inspects the
+	// Go AST + type info against its own side-table (stored in the registry
+	// during Transform). The engine walks plugins in priority order; the
+	// pipeline does not know which plugins participate. Each plugin's own
+	// Validate determines whether its rules apply to this file (typically
+	// a no-op when the plugin's Transform recorded no annotations).
+	stageStart = time.Now()
+	var typeInfo *types.Info
+	if typeChecker != nil {
+		typeInfo = typeChecker.Info()
+	}
+	if validationErrs := featureEngine.Validate(fset, goFile, typeInfo, filename); len(validationErrs) > 0 {
+		first := validationErrs[0]
+		label := first.Plugin
+		if label == "" {
+			label = "validation"
+		}
+		return TranspileResult{}, fmt.Errorf("%s check error at %s:%d:%d: %s",
+			label, filename, first.Line, first.Column, first.Message)
+	}
+	logTiming("Step 3.55: Feature validators", stageStart)
 
 	// Step 3.6: Inject dgo import if Result/Option types are detected
 	InjectDgoImport(fset, goFile)


### PR DESCRIPTION
## Summary

Adds the plumbing that lets out-of-tree feature plugins (e.g. `dingo-mut`) hook into the transpilation pipeline without the core having to know about them by name. No built-in plugin participates yet — this PR is pure infrastructure.

### 1. New `Validator` plugin extension (`pkg/feature/plugin.go`)

- Optional interface: any `Plugin` can additionally implement `Validator` to run a post-typecheck pass against the Go AST and `go/types.Info`.
- New `ValidateContext` carries `FileSet`, `GoFile`, `TypeInfo`, the shared cross-phase `Registry`, and the original Dingo filename.
- New `ValidationError` (Plugin, Pos, Line, Column, Message) with an `Error()` method so diagnostics flow through the usual error machinery.

### 2. `Engine.Validate` + `Engine.IsEnabled` (`pkg/feature/engine.go`)

- `Engine.Validate(fset, file, info, filename)` walks every enabled plugin in the same priority order as `Transform` (character-level first, then token-level), collects each `Validator`'s `[]ValidationError`, and back-fills `Plugin` from `p.Name()` when the plugin left it blank.
- `Engine.IsEnabled(name)` exposes the existing internal predicate so pipeline callers can gate optional phases on a specific plugin's config without scanning `EnabledPluginNames`.

### 3. Pipeline hook (`pkg/transpiler/pure_pipeline.go`)

- **Step 0.5** — run `Engine.TransformCharacterLevel` over the raw source before any built-in transformation. The pipeline does not know which plugins participate; built-ins and externals look identical from here.
- **Step 3.55** — after parsing + typechecking, run `Engine.Validate`. On the first error the pipeline aborts with `<plugin> check error at <file>:<line>:<col>: <msg>`, falling back to the literal label `validation` when the plugin did not name itself.
- The `Engine` and the `feature.EnabledFeatures` map are constructed once near the top of the pipeline so both phases share them.

### Why this is split out

The mutability work (separate plugin, separate repo) needs a stable surface to plug into. Landing the plumbing on its own keeps that PR's diff focused on the actual mutability semantics rather than the engine wiring.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/feature/... ./pkg/transpiler/...`
- [x] CLAUDE.md forbidden-pattern check on touched files (no new `bytes.Index` / `strings.Index` / regex / byte-offset scans introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)