### PR TITLE
fix(ci): pin Pages deployment to pnpm 9

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
         uses: withastro/action@v5
         with:
           path: ./langingpage
-          package-manager: pnpm@latest
+          package-manager: pnpm@9
           node-version: 22
         env:
           # Firebase config from GitHub secrets


### PR DESCRIPTION
## Summary

- pin the Astro Pages action to the same pnpm 9 major already configured by the workflow
- prevent pnpm latest from failing installation on ignored dependency build scripts

## Validation

- reproduced the failed main workflow: pnpm latest exits on ignored builds for Firebase, esbuild, protobufjs, and sharp
- ran CI-mode install with pnpm 9.15.9
- ran the full Astro production build successfully

This repairs the post-merge Pages failure from run 29185918438.